### PR TITLE
Add responsive admin and user dashboards

### DIFF
--- a/app/(protected)/admin/dashboard/page.tsx
+++ b/app/(protected)/admin/dashboard/page.tsx
@@ -1,0 +1,88 @@
+import { DashboardLayout, MetricCard, QuickActionCard } from "@/app/components/dashboard";
+
+const adminMetrics = [
+  {
+    label: "Usuarios activos",
+    value: "1,248",
+    trendLabel: "Últimos 30 días",
+    trendValue: "+6%",
+    highlight: "up" as const,
+  },
+  {
+    label: "Roles asignados",
+    value: "327",
+    trendLabel: "Cambios recientes",
+    trendValue: "+12",
+    highlight: "up" as const,
+  },
+  {
+    label: "Solicitudes pendientes",
+    value: "18",
+    trendLabel: "Revisión requerida",
+    trendValue: "+4",
+    highlight: "down" as const,
+  },
+];
+
+const quickAdminActions = [
+  {
+    title: "Sincronizar directorio",
+    description: "Obtén los últimos usuarios del IdP empresarial.",
+    actionLabel: "Sincronizar",
+    icon: "🔄",
+  },
+  {
+    title: "Generar reporte",
+    description: "Descarga métricas y auditorías en CSV.",
+    actionLabel: "Descargar",
+    icon: "📊",
+  },
+];
+
+const managementSections = [
+  {
+    title: "Crear Usuarios",
+    description: "Configura accesos iniciales, credenciales y equipos asignados.",
+    actionLabel: "Abrir formulario",
+    icon: "➕",
+  },
+  {
+    title: "Roles",
+    description: "Define permisos avanzados, aprobaciones y jerarquías.",
+    actionLabel: "Editar roles",
+    icon: "🛡️",
+  },
+  {
+    title: "Estatus",
+    description: "Activa, pausa o revoca usuarios con historial de acciones.",
+    actionLabel: "Administrar",
+    icon: "⚙️",
+  },
+];
+
+export default function AdminDashboardPage() {
+  return (
+    <DashboardLayout
+      title="Dashboard Administrador"
+      subtitle="Controla usuarios, roles y estatus en tiempo real"
+    >
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {adminMetrics.map((metric) => (
+          <MetricCard key={metric.label} {...metric} />
+        ))}
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {quickAdminActions.map((action) => (
+          <QuickActionCard key={action.title} {...action} />
+        ))}
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {managementSections.map((section) => (
+          <QuickActionCard key={section.title} {...section} />
+        ))}
+      </section>
+    </DashboardLayout>
+  );
+}

--- a/app/(protected)/admin/layout.tsx
+++ b/app/(protected)/admin/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <div className="min-h-screen bg-slate-950">{children}</div>;
+}

--- a/app/components/dashboard/DashboardLayout.tsx
+++ b/app/components/dashboard/DashboardLayout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+interface DashboardLayoutProps {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export function DashboardLayout({
+  title,
+  subtitle,
+  actions,
+  children,
+}: DashboardLayoutProps) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-10 md:px-12 lg:py-14">
+        <header className="flex flex-col gap-4 text-balance md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Panel
+            </p>
+            <h1 className="text-3xl font-semibold text-white md:text-4xl">{title}</h1>
+            {subtitle && (
+              <p className="mt-1 text-base text-slate-400 md:text-lg">{subtitle}</p>
+            )}
+          </div>
+          {actions}
+        </header>
+        <div className="flex flex-col gap-10">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/MetricCard.tsx
+++ b/app/components/dashboard/MetricCard.tsx
@@ -1,0 +1,28 @@
+interface MetricCardProps {
+  label: string;
+  value: string;
+  trendLabel?: string;
+  trendValue?: string;
+  highlight?: "up" | "down";
+}
+
+export function MetricCard({
+  label,
+  value,
+  trendLabel,
+  trendValue,
+  highlight = "up",
+}: MetricCardProps) {
+  const trendColor = highlight === "up" ? "text-emerald-400" : "text-rose-400";
+  return (
+    <article className="rounded-2xl border border-white/5 bg-gradient-to-b from-white/5 to-white/0 p-6 shadow-xl shadow-black/30">
+      <p className="text-sm font-medium text-slate-400">{label}</p>
+      <p className="mt-2 text-3xl font-semibold text-white md:text-4xl">{value}</p>
+      {trendLabel && trendValue && (
+        <p className={`mt-4 text-sm font-medium ${trendColor}`}>
+          {trendLabel} · {trendValue}
+        </p>
+      )}
+    </article>
+  );
+}

--- a/app/components/dashboard/QuickActionCard.tsx
+++ b/app/components/dashboard/QuickActionCard.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+interface QuickActionCardProps {
+  title: string;
+  description: string;
+  actionLabel: string;
+  icon?: ReactNode;
+  onClick?: () => void;
+}
+
+export function QuickActionCard({
+  title,
+  description,
+  actionLabel,
+  icon,
+  onClick,
+}: QuickActionCardProps) {
+  return (
+    <article className="flex flex-col justify-between rounded-2xl border border-white/5 bg-slate-900/60 p-5 text-left shadow-lg shadow-black/20">
+      <div className="flex items-start gap-3">
+        {icon && <span className="text-lg text-slate-300">{icon}</span>}
+        <div>
+          <h3 className="text-lg font-semibold text-white">{title}</h3>
+          <p className="mt-1 text-sm text-slate-400">{description}</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onClick}
+        className="mt-6 inline-flex items-center justify-center rounded-full bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20"
+      >
+        {actionLabel}
+      </button>
+    </article>
+  );
+}

--- a/app/components/dashboard/index.ts
+++ b/app/components/dashboard/index.ts
@@ -1,0 +1,3 @@
+export * from "./DashboardLayout";
+export * from "./MetricCard";
+export * from "./QuickActionCard";

--- a/app/user/dashboard/page.tsx
+++ b/app/user/dashboard/page.tsx
@@ -1,0 +1,67 @@
+import { DashboardLayout, MetricCard, QuickActionCard } from "@/app/components/dashboard";
+
+const metrics = [
+  {
+    label: "Proyectos activos",
+    value: "12",
+    trendLabel: "vs. mes anterior",
+    trendValue: "+3",
+    highlight: "up" as const,
+  },
+  {
+    label: "Tareas completadas",
+    value: "148",
+    trendLabel: "Semana actual",
+    trendValue: "+28",
+    highlight: "up" as const,
+  },
+  {
+    label: "Alertas",
+    value: "4",
+    trendLabel: "Pendientes",
+    trendValue: "-2",
+    highlight: "down" as const,
+  },
+];
+
+const quickActions = [
+  {
+    title: "Nuevo proyecto",
+    description: "Configura un nuevo flujo para el equipo.",
+    actionLabel: "Crear",
+    icon: "🚀",
+  },
+  {
+    title: "Registrar avance",
+    description: "Actualiza el estado de tus tareas prioritarias.",
+    actionLabel: "Actualizar",
+    icon: "📝",
+  },
+  {
+    title: "Solicitar soporte",
+    description: "Comunícate con el equipo de operaciones.",
+    actionLabel: "Abrir ticket",
+    icon: "💬",
+  },
+];
+
+export default function UserDashboardPage() {
+  return (
+    <DashboardLayout
+      title="Dashboard de Usuario"
+      subtitle="Resumen personal y acciones rápidas"
+    >
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.label} {...metric} />
+        ))}
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {quickActions.map((action) => (
+          <QuickActionCard key={action.title} {...action} />
+        ))}
+      </section>
+    </DashboardLayout>
+  );
+}

--- a/app/user/layout.tsx
+++ b/app/user/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function UserLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <div className="min-h-screen bg-slate-950">{children}</div>;
+}


### PR DESCRIPTION
## Summary
- add shared dashboard layout plus reusable metric and quick-action components
- build a user dashboard that reuses the shared tokens and components
- create the admin dashboard with dedicated management sections for usuarios, roles y estatus

## Testing
- `npm run build` *(fails: next/font could not download Geist/Geist Mono from Google Fonts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c03b77ac083218852731e2f1c0a98)