### PR TITLE
Add user status controls with admin validation

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sanitizeUser, users } from "../users/data";
+
+export async function POST(request: NextRequest) {
+  const { email, password } = await request.json();
+
+  const user = users.find((u) => u.email === email);
+
+  if (!user || user.password !== password) {
+    return NextResponse.json({ message: "Credenciales inválidas." }, { status: 401 });
+  }
+
+  if (user.status === "inactive") {
+    return NextResponse.json(
+      { message: "Tu cuenta está inactiva. Contacta al administrador." },
+      { status: 403 }
+    );
+  }
+
+  return NextResponse.json(sanitizeUser(user));
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sanitizeUser, users, UserStatus } from "../data";
+
+const allowedStatuses: UserStatus[] = ["active", "inactive", "suspended"];
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const role = request.headers.get("x-user-role");
+  if (role !== "admin") {
+    return NextResponse.json(
+      { message: "Solo los administradores pueden actualizar el estatus." },
+      { status: 403 }
+    );
+  }
+
+  const { status } = await request.json();
+
+  if (!allowedStatuses.includes(status)) {
+    return NextResponse.json(
+      { message: "Estatus no válido." },
+      { status: 400 }
+    );
+  }
+
+  const user = users.find((u) => u.id === params.id);
+
+  if (!user) {
+    return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+  }
+
+  user.status = status;
+
+  return NextResponse.json(sanitizeUser(user));
+}

--- a/app/api/users/data.ts
+++ b/app/api/users/data.ts
@@ -1,0 +1,55 @@
+export type UserStatus = "active" | "inactive" | "suspended";
+export type UserRole = "admin" | "user";
+
+export interface UserRecord {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  status: UserStatus;
+  title: string;
+}
+
+export const users: UserRecord[] = [
+  {
+    id: "1",
+    name: "Rosa Herrera",
+    email: "rosa@example.com",
+    password: "rosa123",
+    role: "admin",
+    status: "active",
+    title: "Gerente de TI",
+  },
+  {
+    id: "2",
+    name: "Luis García",
+    email: "luis@example.com",
+    password: "luis123",
+    role: "user",
+    status: "inactive",
+    title: "Analista de Datos",
+  },
+  {
+    id: "3",
+    name: "Mónica Díaz",
+    email: "monica@example.com",
+    password: "monica123",
+    role: "user",
+    status: "active",
+    title: "Diseñadora UX",
+  },
+  {
+    id: "4",
+    name: "Carlos Pérez",
+    email: "carlos@example.com",
+    password: "carlos123",
+    role: "user",
+    status: "suspended",
+    title: "Soporte Técnico",
+  },
+];
+
+export function sanitizeUser({ password, ...rest }: UserRecord) {
+  return rest;
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { sanitizeUser, users } from "./data";
+
+export async function GET() {
+  return NextResponse.json(users.map(sanitizeUser));
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,266 @@
-import Image from "next/image";
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+export type UserStatus = "active" | "inactive" | "suspended";
+export type UserRole = "admin" | "user";
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  status: UserStatus;
+  title: string;
+}
+
+const STATUS_LABELS: Record<UserStatus, string> = {
+  active: "Activo",
+  inactive: "Inactivo",
+  suspended: "Suspendido",
+};
+
+const statusOptions: UserStatus[] = ["active", "inactive", "suspended"];
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [users, setUsers] = useState<User[]>([]);
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [email, setEmail] = useState("rosa@example.com");
+  const [password, setPassword] = useState("rosa123");
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+  const isAdmin = currentUser?.role === "admin";
+
+  const fetchUsers = async () => {
+    const res = await fetch("/api/users");
+    const data = await res.json();
+    setUsers(data);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        setMessage(error.message || "No se pudo iniciar sesión.");
+        setCurrentUser(null);
+        setLoading(false);
+        return;
+      }
+
+      const user = await res.json();
+      setCurrentUser(user);
+      setMessage("Sesión iniciada correctamente.");
+      setLoading(false);
+    } catch (error) {
+      console.error(error);
+      setMessage("No se pudo iniciar sesión.");
+      setLoading(false);
+    }
+  };
+
+  const handleStatusChange = async (userId: string, status: UserStatus) => {
+    if (!isAdmin) {
+      setMessage("Sólo un administrador puede cambiar el estatus.");
+      return;
+    }
+    const previousUsers = [...users];
+    setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, status } : u)));
+    try {
+      const res = await fetch(`/api/users/${userId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-user-role": currentUser?.role ?? "user",
+        },
+        body: JSON.stringify({ status }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        setUsers(previousUsers);
+        setMessage(error.message || "No se pudo actualizar el estatus.");
+        return;
+      }
+
+      const updatedUser: User = await res.json();
+      setUsers((prev) => prev.map((u) => (u.id === updatedUser.id ? updatedUser : u)));
+      if (currentUser && currentUser.id === updatedUser.id) {
+        setCurrentUser(updatedUser);
+      }
+      setMessage("Estatus actualizado");
+    } catch (error) {
+      console.error(error);
+      setUsers(previousUsers);
+      setMessage("No se pudo actualizar el estatus.");
+    }
+  };
+
+  const profileUser = useMemo(() => currentUser ?? users[0] ?? null, [currentUser, users]);
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-white px-4 py-10">
+      <div className="max-w-6xl mx-auto space-y-10">
+        <header className="space-y-3">
+          <p className="text-blue-400 text-sm uppercase tracking-[0.4em]">Portal de usuarios</p>
+          <h1 className="text-3xl font-bold">Panel de control</h1>
+          <p className="text-slate-300 max-w-3xl">
+            Administra a los usuarios del sistema, consulta su estatus y controla los accesos. El
+            selector de estatus te permite poner a cada colaborador como Activo, Inactivo o
+            Suspendido de acuerdo con las políticas internas.
+          </p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="bg-slate-900 rounded-2xl p-6 shadow-lg border border-slate-800">
+            <h2 className="text-xl font-semibold mb-4">Inicia sesión</h2>
+            <form className="space-y-4" onSubmit={handleLogin}>
+              <div>
+                <label className="text-sm text-slate-400" htmlFor="email">
+                  Correo electrónico
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  className="mt-1 w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className="text-sm text-slate-400" htmlFor="password">
+                  Contraseña
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  className="mt-1 w-full rounded-lg bg-slate-800 border border-slate-700 px-3 py-2"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full rounded-lg bg-blue-500 hover:bg-blue-400 px-4 py-2 font-semibold"
+                disabled={loading}
+              >
+                {loading ? "Validando..." : "Ingresar"}
+              </button>
+            </form>
+            {message && (
+              <p className="mt-4 text-sm text-slate-300 bg-slate-800 px-3 py-2 rounded-lg">{message}</p>
+            )}
+          </div>
+
+          <div className="bg-slate-900 rounded-2xl p-6 border border-slate-800">
+            <h2 className="text-xl font-semibold mb-4">Perfil</h2>
+            {profileUser ? (
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm text-slate-400">Nombre</p>
+                  <p className="text-lg font-semibold">{profileUser.name}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-slate-400">Correo</p>
+                  <p>{profileUser.email}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-slate-400">Rol</p>
+                  <p className="capitalize">{profileUser.role}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-slate-400">Puesto</p>
+                  <p>{profileUser.title}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-slate-400">Estatus</p>
+                  <StatusBadge status={profileUser.status} />
+                </div>
+              </div>
+            ) : (
+              <p className="text-slate-400">Sin información disponible.</p>
+            )}
+          </div>
+        </section>
+
+        <section className="bg-slate-900 rounded-2xl p-6 border border-slate-800 overflow-x-auto">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Usuarios</h2>
+            <p className="text-sm text-slate-400">
+              {isAdmin
+                ? "Sesión de administrador: puedes cambiar el estatus desde el selector"
+                : "Inicia sesión como admin para editar el estatus"}
+            </p>
+          </div>
+          <table className="min-w-full text-left text-sm">
+            <thead className="text-slate-400">
+              <tr>
+                <th className="py-2">Nombre</th>
+                <th className="py-2">Correo</th>
+                <th className="py-2">Rol</th>
+                <th className="py-2">Estatus</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td className="py-3 font-medium">{user.name}</td>
+                  <td className="py-3 text-slate-300">{user.email}</td>
+                  <td className="py-3 capitalize">{user.role}</td>
+                  <td className="py-3">
+                    <div className="flex items-center gap-3">
+                      <StatusBadge status={user.status} />
+                      <select
+                        className="rounded-md bg-slate-800 border border-slate-700 px-2 py-1 text-white"
+                        value={user.status}
+                        onChange={(event) =>
+                          handleStatusChange(user.id, event.target.value as UserStatus)
+                        }
+                        disabled={!isAdmin}
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option} value={option}>
+                            {STATUS_LABELS[option]}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function StatusBadge({ status }: { status: UserStatus }) {
+  const colorClasses: Record<UserStatus, string> = {
+    active: "bg-green-500/20 text-green-300 border-green-400/40",
+    inactive: "bg-yellow-500/20 text-yellow-200 border-yellow-500/40",
+    suspended: "bg-red-500/20 text-red-200 border-red-500/40",
+  };
+
+  return (
+    <span className={`text-xs font-semibold px-3 py-1 rounded-full border ${colorClasses[status]}`}>
+      {STATUS_LABELS[status]}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- add in-memory user dataset plus login and user endpoints with admin-only status updates
- refresh the dashboard UI with login, profile card, user table, and status selectors that call the backend

## Testing
- `npm run build` *(fails: Turbopack cannot download Geist/Geist Mono fonts from Google Fonts in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c062746948321b47724feb5d03a51)